### PR TITLE
document center class in revealjs

### DIFF
--- a/docs/presentations/revealjs/advanced.qmd
+++ b/docs/presentations/revealjs/advanced.qmd
@@ -186,6 +186,16 @@ Big Text
 :::
 ```
 
+### Center
+
+The `center` class when applied to a slide, will vertically center the slide content by adding the appropriate spacing at the top of the slide. Vertical distances between elements will not be modified. For example:
+
+``` markdown
+## This will be centered {.center}
+
+This text is moved as well
+```
+
 ### Stretch
 
 The `r-stretch` layout helper lets you resize an element, like an image or video, to cover the remaining vertical space in a slide. For example, here the image will automatically be resized to fit space remaining outside of the slide title and text before and after it:


### PR DESCRIPTION
This feature is not officially documented on the revealjs website, but the source is here: https://github.com/hakimel/reveal.js/blob/713702a0ab81d1756a30e6c14ae49afd42135541/js/reveal.js#L1650-L1659

Added back in 2012: https://github.com/hakimel/reveal.js/issues/70

Mentioned in news: https://github.com/hakimel/reveal.js/releases/tag/2.6.0

> Added support for per-slide vertical centering, simply add a .center class to the <section>


It is super neat and should be used